### PR TITLE
Fixed compilation of vxl with gcc >= 5

### DIFF
--- a/vxl/CMakeLists.txt
+++ b/vxl/CMakeLists.txt
@@ -38,7 +38,8 @@ else()
     list(APPEND VXL_CMAKE_ARGS -DBUILD_SHARED_LIBS:BOOL=ON)
     #fixed error: 'constexpr' needed for in-class initialization of static data member 'tolerance' of non-integral type
     # -> define VCL_CAN_STATIC_CONST_INIT_FLOAT to 0
-    set(VXL_PATCH_CMD ${PATCH_EXECUTABLE} -p1 -i ${VXL_PATCH_DIR}/vcl_config_compiler.h.in.diff -d <SOURCE_DIR>)
+    set(VXL_PATCH_CMD ${PATCH_EXECUTABLE} -p1 -i ${VXL_PATCH_DIR}/vcl_config_compiler.h.in.diff -d <SOURCE_DIR>
+              COMMAND ${PATCH_EXECUTABLE} -p1 -i ${VXL_PATCH_DIR}/gcc5.diff -d <SOURCE_DIR>)
     if(ANDROID)
         list(APPEND VXL_PATCH_CMD
             COMMAND ${PATCH_EXECUTABLE} -p1 -i ${VXL_PATCH_DIR}/config_CMakeLists.txt.diff -d <SOURCE_DIR>

--- a/vxl/patch/gcc5.diff
+++ b/vxl/patch/gcc5.diff
@@ -21,3 +21,12 @@ diff -uNr a/vcl/vcl_compiler.h b/vcl/vcl_compiler.h
  # else
  #  error "Dunno about this gcc"
  # endif
+@@ -248,7 +248,7 @@
+ 
+ // This *needs* to come after vcl_config_headers.h
+ #if defined(__GNUC__) && !defined(__INTEL_COMPILER)
+-# if defined(VCL_GCC_3) || defined(VCL_GCC_4)
++# if defined(VCL_GCC_3) || defined(VCL_GCC_4) || defined(VCL_GCC_5)
+ #  define GNU_LIBSTDCXX_V3 1
+ # elif !defined(GNU_LIBSTDCXX_V3) && defined(VCL_GCC_295) && VCL_CXX_HAS_HEADER_ISTREAM
+ // One difference between v2 and v3 is that the former has

--- a/vxl/patch/gcc5.diff
+++ b/vxl/patch/gcc5.diff
@@ -1,0 +1,23 @@
+diff -uNr a/vcl/vcl_compiler.h b/vcl/vcl_compiler.h
+--- a/vcl/vcl_compiler.h	2014-11-14 21:40:27.000000000 +0100
++++ b/vcl/vcl_compiler.h	2016-12-01 15:47:18.862268656 +0100
+@@ -119,6 +119,19 @@
+ #  else
+ #   define VCL_GCC_40
+ #  endif
++# elif (__GNUC__==5)
++#  define VCL_GCC_5
++#  if (__GNUC_MINOR__ > 3 )
++#   define VCL_GCC_54
++#  elif (__GNUC_MINOR__ > 2 )
++#   define VCL_GCC_53
++#  elif (__GNUC_MINOR__ > 1 )
++#   define VCL_GCC_52
++#  elif (__GNUC_MINOR__ > 0 )
++#   define VCL_GCC_51
++#  else
++#   define VCL_GCC_50
++#  endif
+ # else
+ #  error "Dunno about this gcc"
+ # endif


### PR DESCRIPTION
We could even handle greater version but I couldn't test so I prefer no to pretend it does compile.