### PR TITLE
Fixed build of dcmtk with gcc54.

### DIFF
--- a/dcmtk/CMakeLists.txt
+++ b/dcmtk/CMakeLists.txt
@@ -37,7 +37,7 @@ ExternalProject_Add(
     PATCH_COMMAND ${DCMTK_PATCH_CMD}
     INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
     CMAKE_ARGS ${DCMTK_CMAKE_ARGS}
-    DEPENDS tiff libpng
+    DEPENDS tiff libpng libxml
 )
 
 ExternalProject_Add_Step(dcmtk CopyConfigFileToInstall

--- a/dcmtk/CMakeLists.txt
+++ b/dcmtk/CMakeLists.txt
@@ -23,7 +23,7 @@ set(DCMTK_PATCH_CMD ${PATCH_EXECUTABLE} -p1 -i ${DCMTK_PATCH_DIR}/scp_scu.h.diff
 # On Linux-gcc we have a crash on the first call to ::DcmSCP::addPresentationContext() only in debug
 # This is weird but for now we keep the release version
 if(UNIX AND NOT APPLE AND NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-    list(APPEND DCMTK_CMAKE_ARGS -DDCMTK_USE_CXX11_STL:BOOL=ON -DCMAKE_BUILD_TYPE=Release)
+    list(APPEND DCMTK_CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release)
 endif()
 
 set(CACHED_URL http://dicom.offis.de/download/dcmtk/snapshot/old/dcmtk-3.6.1_20150217.tar.gz)


### PR DESCRIPTION
C++11 is apparently badly supported. I just disabled it, Debian does the same (gcc62).