### PR TITLE
Replaced hardcoded french sourceforge mirrors by generic urls.

### DIFF
--- a/boost/CMakeLists.txt
+++ b/boost/CMakeLists.txt
@@ -4,7 +4,7 @@ project(boostBuilder)
 
 include(ExternalProject)
 
-set(CACHED_URL http://freefr.dl.sourceforge.net/boost/boost_1_61_0.tar.gz)
+set(CACHED_URL http://downloads.sourceforge.net/boost/boost_1_61_0.tar.gz)
 set(BOOST_HASHSUM a77c7cc660ec02704c6884fbb20c552d52d60a18f26573c9cee0788bf00ed7e6)
 
 string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE)

--- a/cppunit/CMakeLists.txt
+++ b/cppunit/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cppunitBuilder)
 
 include(ExternalProject)
 
-set(CACHED_URL http://freefr.dl.sourceforge.net/cppunit/cppunit-1.12.1.tar.gz)
+set(CACHED_URL http://downloads.sourceforge.net/cppunit/cppunit-1.12.1.tar.gz)
 
 if(WIN32)
     set(CPPUNIT_PATCH_DIR ${CMAKE_CURRENT_SOURCE_DIR}/patch)

--- a/expat/CMakeLists.txt
+++ b/expat/CMakeLists.txt
@@ -5,9 +5,9 @@ project(expatBuilder)
 include(ExternalProject)
 
 
-set(CACHED_URL http://freefr.dl.sourceforge.net/expat/expat-2.1.0.tar.gz)
+set(CACHED_URL http://downloads.sourceforge.net/expat/expat-2.1.0.tar.gz)
 
-set(EXPAT_CMAKE_ARGS 
+set(EXPAT_CMAKE_ARGS
     ${COMMON_CMAKE_ARGS}
     -DBUILD_tools=FALSE
     -DBUILD_examples=FALSE
@@ -17,7 +17,7 @@ set(EXPAT_CMAKE_ARGS
 set(EXPAT_PATCH_DIR ${CMAKE_CURRENT_SOURCE_DIR}/patch)
 
 if(ANDROID OR WIN32)
-            
+
     ExternalProject_Add(
         expat
         URL ${CACHED_URL}

--- a/itk/CMakeLists.txt
+++ b/itk/CMakeLists.txt
@@ -10,7 +10,7 @@ set(ITK_CMAKE_ARGS ${COMMON_CMAKE_ARGS}
                    -DBUILD_TESTING:BOOL=OFF
                    -DBUILD_DOXYGEN:BOOL=OFF
                    -DITK_USE_REVIEW:BOOL=ON
-                   
+
                    -DITK_USE_SYSTEM_DCMTK:BOOL=ON
                    -DITK_USE_SYSTEM_GDCM:BOOL=ON
                    -DITK_USE_SYSTEM_PNG:BOOL=ON
@@ -19,7 +19,7 @@ set(ITK_CMAKE_ARGS ${COMMON_CMAKE_ARGS}
                    -DITK_USE_SYSTEM_ZLIB:BOOL=ON
                    -DITK_USE_SYSTEM_JPEG:BOOL=ON
                    -DITK_USE_OPTIMIZED_REGISTRATION_METHODS:BOOL=ON
-                   
+
                    -DITK_BUILD_DEFAULT_MODULES:BOOL=OFF
                    -DModule_ITKDeprecated:BOOL=OFF
                    -DModule_ITKMINC:BOOL=OFF
@@ -29,7 +29,7 @@ set(ITK_CMAKE_ARGS ${COMMON_CMAKE_ARGS}
                    -DModule_ITKDCMTK:BOOL=OFF
                    -DModule_ITKIODCMTK:BOOL=OFF
                    -DModule_ITKIOHDF5:BOOL=OFF
-                   
+
 
                    -DModule_ITKAnisotropicSmoothing:BOOL=ON
                    -DModule_ITKAntiAlias:BOOL=ON
@@ -87,7 +87,7 @@ set(ITK_CMAKE_ARGS ${COMMON_CMAKE_ARGS}
                    -DModule_ITKLabelVoting:BOOL=ON
                    -DModule_ITKLevelSets:BOOL=ON
                    -DModule_ITKLevelSetsv4:BOOL=ON
-                                     
+
                    -DModule_ITKMarkovRandomFieldsClassifiers:BOOL=ON
                    -DModule_ITKMathematicalMorphology:BOOL=ON
                    -DModule_ITKMetricsv4:BOOL=ON
@@ -107,7 +107,7 @@ set(ITK_CMAKE_ARGS ${COMMON_CMAKE_ARGS}
                    -DModule_ITKSmoothing:BOOL=ON
                    -DModule_ITKSpatialFunction:BOOL=ON
                    -DModule_ITKThresholding:BOOL=ON
-                   
+
                    -DModule_ITKVideoCore:BOOL=ON
                    -DModule_ITKVideoFiltering:BOOL=ON
                    -DModule_ITKVideoIO:BOOL=ON
@@ -119,12 +119,12 @@ set(ITK_CMAKE_ARGS ${COMMON_CMAKE_ARGS}
                    # Disabled on Linux (link errors)
                    -DModule_ITKLevelSetsv4Visualization:BOOL=OFF
                    -DModule_ITKVtkGlue:BOOL=OFF
-                   
+
                    # Disabled because Vxl vidl is not build anymore
                    -DModule_ITKVideoBridgeVXL:BOOL=OFF
 )
 
-set(CACHED_URL http://freefr.dl.sourceforge.net/project/itk/itk/4.6/InsightToolkit-4.6.1.tar.gz)
+set(CACHED_URL http://downloads.sourceforge.net/project/itk/itk/4.6/InsightToolkit-4.6.1.tar.gz)
 set(ITK_PATCH_DIR ${CMAKE_CURRENT_SOURCE_DIR}/patch)
 set(ITK_PATCH_CMD "${PATCH_EXECUTABLE}" -p1 -i ${ITK_PATCH_DIR}/CMakeLists.txt.diff -d <SOURCE_DIR>
     && "${PATCH_EXECUTABLE}" -p1 -i ${ITK_PATCH_DIR}/ConfigureChecks.cmake.diff -d <SOURCE_DIR>/Modules/ThirdParty/HDF5/src/itkhdf5/config/cmake)
@@ -140,7 +140,7 @@ ExternalProject_Add(
     CMAKE_ARGS ${ITK_CMAKE_ARGS}
 )
 
-ExternalProject_Add_Step(itk CopyConfigFileToInstall 
+ExternalProject_Add_Step(itk CopyConfigFileToInstall
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/cmake/findBinpkgs/fw-ITK.cmake ${CMAKE_INSTALL_PREFIX}/fw-ITK.cmake
     COMMENT "Install configuration file"
     DEPENDEES install

--- a/png/CMakeLists.txt
+++ b/png/CMakeLists.txt
@@ -4,7 +4,7 @@ project(pngBuilder)
 
 include(ExternalProject)
 
-set(CACHED_URL http://freefr.dl.sourceforge.net/libpng/libpng-1.6.21.tar.gz)
+set(CACHED_URL https://github.com/glennrp/libpng/archive/v1.6.21.tar.gz)
 set(PNG_CMAKE_ARGS  ${COMMON_CMAKE_ARGS}
                     -DPNG_DEBUG:BOOL=OFF
                     -DPNG_SHARED:BOOL=ON
@@ -19,7 +19,7 @@ ExternalProject_Add(
         libpng
         DEPENDS zlib
         URL ${CACHED_URL}
-        URL_HASH SHA256=b36a3c124622c8e1647f360424371394284f4c6c4b384593e478666c59ff42d3
+        URL_HASH SHA256=caa0f62d09452bf3018a7e22973246f62b5818c7bf86c466009ab11a68f0a137
         DOWNLOAD_DIR ${ARCHIVE_DIR}
         PATCH_COMMAND ${LIBPNG_PATCH_CMD}
         INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
@@ -35,8 +35,8 @@ set(LIBPNG_LIB_NAME ${LIBPNG_LIB_NAME} PARENT_SCOPE)
 
 if(WIN32)
     ExternalProject_Add_Step(libpng RENAME_LIBPNG
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LIBPNG_LIB_NAME}.lib libpng.lib 
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LIBPNG_LIB_NAME}.lib png.lib 
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LIBPNG_LIB_NAME}.lib libpng.lib
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${LIBPNG_LIB_NAME}.lib png.lib
         WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/lib
         DEPENDEES install
         )

--- a/zzip/CMakeLists.txt
+++ b/zzip/CMakeLists.txt
@@ -6,7 +6,7 @@ include(ExternalProject)
 
 set(ZZIP_VERSION 0.13.62)
 
-set(CACHED_URL http://freefr.dl.sourceforge.net/project/zziplib/zziplib13/${ZZIP_VERSION}/zziplib-${ZZIP_VERSION}.tar.bz2)
+set(CACHED_URL http://downloads.sourceforge.net/project/zziplib/zziplib13/${ZZIP_VERSION}/zziplib-${ZZIP_VERSION}.tar.bz2)
 
 set(ZZIP_PATCH_DIR ${CMAKE_CURRENT_SOURCE_DIR}/patch)
 


### PR DESCRIPTION
Answer to reported issue in main repo https://github.com/fw4spl-org/fw4spl-doc/issues/1
Normally there should be nothing left.